### PR TITLE
fix bug when acking deliveries due to binding on publisher channel

### DIFF
--- a/amqptest/server/channel.go
+++ b/amqptest/server/channel.go
@@ -98,6 +98,11 @@ func (ch *Channel) Consume(queue, consumerName string, _ wabbit.Option) (<-chan 
 				close(c.deliveries)
 				return
 			case d := <-q.data:
+				// since we keep track of unacked messages for
+				// the channel, we need to rebind the delivery
+				// to the consumer channel.
+				d = NewDelivery(ch, d.Body(), d.DeliveryTag())
+
 				ch.addUnacked(d, q)
 
 				// sub-select required for cases when


### PR DESCRIPTION
I came across a bug where a consumer channel receives a Delivery object, which is bound to the channel of the publisher. When you do a `d.Ack()` it operates on the `d.channel.unacked` where `d.channel` belongs to the publisher and not the consumer. If not dealt with appropriately, performing `d.Ack()` on a closed publisher can lead to indexing the publisher channel `unacked` and be out of range leading to a panic (since only the consumer adds to it's own copy of `unacked`).

I wrote a test case to demonstrate this.

**With the patch:**
```
$ go test -v
=== RUN   TestBasicConsumer
--- PASS: TestBasicConsumer (0.00s)
=== RUN   TestUnackedMessagesArentLost
--- PASS: TestUnackedMessagesArentLost (0.00s)
=== RUN   TestAckedMessagesAreCommited
--- PASS: TestAckedMessagesAreCommited (2.00s)
=== RUN   TestPublishThenConsumeAck
--- PASS: TestPublishThenConsumeAck (0.00s)
=== RUN   TestNAckedMessagesAreRequeued
--- PASS: TestNAckedMessagesAreRequeued (0.00s)
=== RUN   TestNAckedMessagesAreRejectedWhenRequested
--- PASS: TestNAckedMessagesAreRejectedWhenRequested (2.01s)
=== RUN   TestRejectedMessagesAreRequeuedWhenRequested
--- PASS: TestRejectedMessagesAreRequeuedWhenRequested (0.00s)
=== RUN   TestRejectedMessagesAreRejectedWhenRequested
--- PASS: TestRejectedMessagesAreRejectedWhenRequested (2.00s)
=== RUN   TestTopicMatch
--- PASS: TestTopicMatch (0.00s)
=== RUN   TestVHostWithDefaults
--- PASS: TestVHostWithDefaults (0.00s)
=== RUN   TestQueueDeclare
--- PASS: TestQueueDeclare (0.00s)
=== RUN   TestBasicExchangeDeclare
--- PASS: TestBasicExchangeDeclare (0.00s)
=== RUN   TestQueueBind
--- PASS: TestQueueBind (0.00s)
=== RUN   TestBasicPublish
--- PASS: TestBasicPublish (0.00s)
PASS
ok  	github.com/NeowayLabs/wabbit/amqptest/server	6.024s
```

**Without the patch:**
```
$ go test -v
=== RUN   TestBasicConsumer
--- PASS: TestBasicConsumer (0.00s)
=== RUN   TestUnackedMessagesArentLost
--- PASS: TestUnackedMessagesArentLost (0.00s)
=== RUN   TestAckedMessagesAreCommited
--- PASS: TestAckedMessagesAreCommited (2.00s)
=== RUN   TestPublishThenConsumeAck
panic: runtime error: slice bounds out of range

goroutine 36 [running]:
panic(0x1cb200, 0xc820012090)
	/usr/local/Cellar/go/1.6.3/libexec/src/runtime/panic.go:481 +0x3e6
github.com/NeowayLabs/wabbit/amqptest/server.(*Channel).Ack(0xc8200f4000, 0x1, 0xc8200eef00, 0x0, 0x0)
	/Users/naveen/workspace/src/github.com/NeowayLabs/wabbit/amqptest/server/channel.go:156 +0x287
github.com/NeowayLabs/wabbit/amqptest/server.(*Delivery).Ack(0xc8200fe000, 0x0, 0x0, 0x0)
	/Users/naveen/workspace/src/github.com/NeowayLabs/wabbit/amqptest/server/delivery.go:23 +0x43
github.com/NeowayLabs/wabbit/amqptest/server.TestPublishThenConsumeAck.func1(0xc8200e60c0, 0xc8200e8000, 0xc8200e6180)
	/Users/naveen/workspace/src/github.com/NeowayLabs/wabbit/amqptest/server/channel_test.go:364 +0xfc
created by github.com/NeowayLabs/wabbit/amqptest/server.TestPublishThenConsumeAck
	/Users/naveen/workspace/src/github.com/NeowayLabs/wabbit/amqptest/server/channel_test.go:367 +0x1495
exit status 2
FAIL	github.com/NeowayLabs/wabbit/amqptest/server	2.015s
```