### PR TITLE
Implement rudimentary support for publisher confirmations.

### DIFF
--- a/amqp.go
+++ b/amqp.go
@@ -20,6 +20,9 @@ type (
 		Nack(tag uint64, multiple bool, requeue bool) error
 		Reject(tag uint64, requeue bool) error
 
+		Confirm(noWait bool) error
+		NotifyPublish(confirm chan Confirmation) chan Confirmation
+
 		Cancel(consumer string, noWait bool) error
 		ExchangeDeclare(name, kind string, opt Option) error
 		QueueDeclare(name string, args Option) (Queue, error)
@@ -53,6 +56,12 @@ type (
 		Body() []byte
 		DeliveryTag() uint64
 		ConsumerTag() string
+	}
+
+	// Confirmation is an interface to confrimation messages
+	Confirmation interface {
+		Ack() bool
+		DeliveryTag() uint64
 	}
 
 	// Error is an interface for AMQP errors

--- a/amqp/confirmation.go
+++ b/amqp/confirmation.go
@@ -1,0 +1,15 @@
+package amqp
+
+import "github.com/streadway/amqp"
+
+type Confirmation struct {
+	amqp.Confirmation
+}
+
+func (c Confirmation) Ack() bool {
+	return c.Confirmation.Ack
+}
+
+func (c Confirmation) DeliveryTag() uint64 {
+	return c.Confirmation.DeliveryTag
+}

--- a/amqptest/server/confirmation.go
+++ b/amqptest/server/confirmation.go
@@ -1,0 +1,14 @@
+package server
+
+type Confirmation struct {
+	deliveryTag uint64
+	ack         bool
+}
+
+func (c Confirmation) Ack() bool {
+	return c.ack
+}
+
+func (c Confirmation) DeliveryTag() uint64 {
+	return c.deliveryTag
+}


### PR DESCRIPTION
This is very rudimentary support for publish confirmations and currently only supports the `NotifyPublish`.

~~Let me know if you would like a unit test in amqptest.go. I could incorporate it into the exiting TestPubSub or create a new test scenario.~~ I incorporated publisher confirms in the TestPubSub.