### PR TITLE
amqptest/server: fix Nack panic when there's no unacked messages

### DIFF
--- a/amqptest/server/channel.go
+++ b/amqptest/server/channel.go
@@ -248,10 +248,16 @@ func (ch *Channel) Nack(tag uint64, multiple bool, requeue bool) error {
 	)
 
 	if !multiple {
+		found := false
 		for pos, ud = range ch.unacked {
 			if ud.d.DeliveryTag() == tag {
+				found = true
 				break
 			}
+		}
+
+		if !found {
+			return fmt.Errorf("Delivery tag %d not found", tag)
 		}
 
 		if requeue {


### PR DESCRIPTION
This fixes a possible race condition when you close a channel and then call reject/nack.