### PR TITLE
Fixed deliveries proxying when prefetchCount > 1

### DIFF
--- a/amqp/channel.go
+++ b/amqp/channel.go
@@ -105,7 +105,8 @@ func (ch *Channel) Consume(queue, consumer string, opt wabbit.Option) (<-chan wa
 
 	go func() {
 		for d := range amqpd {
-			deliveries <- &Delivery{&d}
+			delivery := d
+			deliveries <- &Delivery{&delivery}
 		}
 
 		close(deliveries)


### PR DESCRIPTION
The problem is that every new iteration of `for loop` changes messages, that were already sent to deliveries channel. If deliveries were not processed by that time, they will be lost.
This problem arises only when we set prefetchCount>1 with channel.Qos().