### PR TITLE
amqptest: Conn.Close() disconnect from the server cleanly

### DIFF
--- a/utils/broadcast.go
+++ b/utils/broadcast.go
@@ -34,6 +34,17 @@ func (b *ErrBroadcast) Add(c chan<- wabbit.Error) {
 	b.listeners = append(b.listeners, c)
 }
 
+// Delete the listener
+func (b *ErrBroadcast) Delete(c chan<- wabbit.Error) {
+	i, ok := b.findIndex(c)
+	if !ok {
+		return
+	}
+	b.listeners[i] = b.listeners[len(b.listeners)-1]
+	b.listeners[len(b.listeners)-1] = nil
+	b.listeners = b.listeners[:len(b.listeners)-1]
+}
+
 // Write to subscribed channels
 func (b *ErrBroadcast) Write(err wabbit.Error) {
 	b.c <- err
@@ -43,4 +54,13 @@ func (b *ErrBroadcast) spread(err wabbit.Error) {
 	for _, l := range b.listeners {
 		l <- err
 	}
+}
+
+func (b *ErrBroadcast) findIndex(c chan<- wabbit.Error) (int, bool) {
+	for i := range b.listeners {
+		if b.listeners[i] == c {
+			return i, true
+		}
+	}
+	return -1, false
 }

--- a/utils/broadcast_test.go
+++ b/utils/broadcast_test.go
@@ -33,3 +33,76 @@ func TestBroadcast(t *testing.T) {
 		}
 	}
 }
+
+func TestBroadcastDelete(t *testing.T) {
+	tests := []struct {
+		name      string
+		listener  int
+		placement int
+	}{
+		{
+			name:     "delete from zero listener",
+			listener: 0,
+		},
+		{
+			name:      "delete from one listener",
+			listener:  1,
+			placement: 0,
+		},
+		{
+			name:      "delete the first from 64 listeners",
+			listener:  64,
+			placement: 0,
+		},
+		{
+			name:      "delete the middle from 64 listeners",
+			listener:  64,
+			placement: 31,
+		},
+		{
+			name:      "delete the last from 64 listeners",
+			listener:  64,
+			placement: 63,
+		},
+		{
+			name:      "delete out of bound from 64 listeners",
+			listener:  64,
+			placement: 64,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spread := NewErrBroadcast()
+			del := make(chan wabbit.Error)
+
+			for i := 0; i < tc.listener; i++ {
+				if i == tc.placement {
+					spread.Add(del)
+				} else {
+					spread.Add(make(chan wabbit.Error))
+				}
+			}
+			if tc.placement < tc.listener {
+				i, ok := spread.findIndex(del)
+				if !ok || i != tc.placement {
+					t.Errorf("add failed")
+				}
+			}
+
+			spread.Delete(del)
+			_, ok := spread.findIndex(del)
+			if ok {
+				t.Errorf("delete failed")
+			}
+
+			if tc.placement < tc.listener {
+				got, want := len(spread.listeners), tc.listener-1
+				if got != want {
+					t.Errorf("unexpected listner size:\n- want: %d\n-  got: %d",
+						want, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This will prevent the goroutines inside amqptest/server to
hang when we call Server.Stop(), due to the channel notification
without having listeners.