### PR TITLE
Add Headers method to Delivery interface for message header support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ services:
 go:
   - tip
   - 1.8
-  - 1.7
 install:
   - go get -d -v ./...
   - go build

--- a/amqp.go
+++ b/amqp.go
@@ -54,6 +54,7 @@ type (
 		Reject(requeue bool) error
 
 		Body() []byte
+		Headers() Option
 		DeliveryTag() uint64
 		ConsumerTag() string
 	}

--- a/amqp/delivery.go
+++ b/amqp/delivery.go
@@ -1,6 +1,9 @@
 package amqp
 
-import "github.com/streadway/amqp"
+import (
+	"github.com/NeowayLabs/wabbit"
+	"github.com/streadway/amqp"
+)
 
 type Delivery struct {
 	*amqp.Delivery
@@ -8,6 +11,10 @@ type Delivery struct {
 
 func (d *Delivery) Body() []byte {
 	return d.Delivery.Body
+}
+
+func (d *Delivery) Headers() wabbit.Option {
+	return wabbit.Option(d.Delivery.Headers)
 }
 
 func (d *Delivery) DeliveryTag() uint64 {

--- a/amqptest/server/delivery.go
+++ b/amqptest/server/delivery.go
@@ -1,9 +1,12 @@
 package server
 
+import "github.com/NeowayLabs/wabbit"
+
 type (
 	// Delivery is an interface to delivered messages
 	Delivery struct {
 		data          []byte
+		headers       wabbit.Option
 		tag           uint64
 		consumerTag   string
 		originalRoute string
@@ -11,9 +14,10 @@ type (
 	}
 )
 
-func NewDelivery(ch *Channel, data []byte, tag uint64) *Delivery {
+func NewDelivery(ch *Channel, data []byte, tag uint64, hdrs wabbit.Option) *Delivery {
 	return &Delivery{
 		data:    data,
+		headers: hdrs,
 		channel: ch,
 		tag:     tag,
 	}
@@ -33,6 +37,10 @@ func (d *Delivery) Reject(requeue bool) error {
 
 func (d *Delivery) Body() []byte {
 	return d.data
+}
+
+func (d *Delivery) Headers() wabbit.Option {
+	return d.headers
 }
 
 func (d *Delivery) DeliveryTag() uint64 {

--- a/amqptest/server/vhost_test.go
+++ b/amqptest/server/vhost_test.go
@@ -1,6 +1,10 @@
 package server
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/NeowayLabs/wabbit"
+)
 
 func TestVHostWithDefaults(t *testing.T) {
 	vh := NewVHost("/")
@@ -113,7 +117,7 @@ func TestQueueBind(t *testing.T) {
 		return
 	}
 
-	err = nwExchange.route("process.data", NewDelivery(&Channel{}, []byte{}, 1))
+	err = nwExchange.route("process.data", NewDelivery(&Channel{}, []byte{}, 1, wabbit.Option{}))
 
 	if err != nil {
 		t.Error(err)
@@ -150,7 +154,7 @@ func TestBasicPublish(t *testing.T) {
 		return
 	}
 
-	err = vh.Publish("neoway", "process.data", NewDelivery(&Channel{}, []byte("teste"), 1), nil)
+	err = vh.Publish("neoway", "process.data", NewDelivery(&Channel{}, []byte("teste"), 1, wabbit.Option{}), nil)
 
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
This change adds `Headers` method to the `wabbit.Delivery` to allow headers passed around the wabbit based test environment.  Here is the corresponding part of the `amqp.Delivery` documentaion, just for your reference.

https://godoc.org/github.com/streadway/amqp#Delivery