### PR TITLE
synchronize channel creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 
 go:
   - tip
-  - 1.9
+  - "1.9"
 install:
   - go get -d -v ./...
   - go build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 
 go:
   - tip
-  - 1.8
+  - 1.9
 install:
   - go get -d -v ./...
   - go build

--- a/amqptest/server/server.go
+++ b/amqptest/server/server.go
@@ -46,6 +46,9 @@ func newServer(amqpuri string) *AMQPServer {
 
 // CreateChannel returns a new fresh channel
 func (s *AMQPServer) CreateChannel(connID string, conn wabbit.Conn) (wabbit.Channel, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
 	if _, ok := s.channels[connID]; !ok {
 		s.channels[connID] = make([]*Channel, 0, MaxChannels)
 	}


### PR DESCRIPTION
We also need to synchronize amqptest's `AMQPServer.CreateChannel()` method. Otherwise, trying to create channels concurrently would result in a race for the map `s.channels`.