### PR TITLE
implement DialConfig() and DialTLS(), also fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 
 go:
   - tip
-  - "1.9"
+  - "1.14"
 install:
   - go get -d -v ./...
   - go build

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
   - go get github.com/fsouza/go-dockerclient
   - go get github.com/tiago4orion/conjure
   - go get golang.org/x/tools/cmd/cover
+  - docker pull rabbitmq
   - hack/check.sh
 #  - goveralls -coverprofile=coverage.txt -service=travis-ci
 before_install:

--- a/hack/check.sh
+++ b/hack/check.sh
@@ -32,7 +32,6 @@ if [ "${DOCKERPATH}" != "not found" ]; then
     TAGS="-tags integration"
 fi
 
-
 # Standard $GO tooling behavior is to ignore dirs with leading underscors
 for dir in $(find "$TEST_DIRECTORY" -maxdepth 10 -not -path './_examples*' -not -path './.git*' -not -path './Godeps/*' -type d);
 do


### PR DESCRIPTION
This addresses #43 and #35, by wrapping `DialConfig()` and `DialTLS()`. 
Also adds tests and fixes the CI, potentially  addressing #33.
To fix the CI, one needs to bump the Go version used for the  CI to 1.14. The dependency `github.com/fsouza/go-dockerclient` (and its dependencies) now uses code introduced in Go 1.14 and will not compile on 1.9.