### PR TITLE
amqptest/server: remove QueueInspect()

### DIFF
--- a/amqptest/server/vhost.go
+++ b/amqptest/server/vhost.go
@@ -90,12 +90,6 @@ func (v *VHost) exchangeDeclare(name, kind string, passive bool, opt wabbit.Opti
 
 	return nil
 }
-func (v *VHost) QueueInspect(name string) (wabbit.Queue, error) {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-
-	return v.QueueInspect(name)
-}
 
 func (v *VHost) QueueDeclare(name string, args wabbit.Option) (wabbit.Queue, error) {
 	v.mu.Lock()


### PR DESCRIPTION
`VHost.QueueInspect()` grabs a lock, and then calls itself. I suspect it was meant to be the public function that calls a private `VHost.queueInspect()`, but no such function exists.

This removes `QueueInspect()`.