### PR TITLE
Improving Channel and Connection interfaces

### DIFF
--- a/amqp.go
+++ b/amqp.go
@@ -2,7 +2,11 @@
 // implementation of that interface.
 package wabbit
 
-import "time"
+import (
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
 
 type (
 	// Option is a map of AMQP configurations
@@ -39,6 +43,7 @@ type (
 		Qos(prefetchCount, prefetchSize int, global bool) error
 		Close() error
 		IsClosed() bool
+		PublishWithDeferredConfirm(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) (*amqp.DeferredConfirmation, error)
 		NotifyClose(chan Error) chan Error
 		Publisher
 	}
@@ -52,7 +57,7 @@ type (
 
 	// Publisher is an interface to something able to publish messages
 	Publisher interface {
-		Publish(exc, route string, msg []byte, opt Option) error
+		Publish(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
 	}
 
 	// Delivery is an interface to delivered messages

--- a/amqp.go
+++ b/amqp.go
@@ -14,6 +14,7 @@ type (
 		AutoRedial(errChan chan Error, done chan bool)
 		Close() error
 		NotifyClose(chan Error) chan Error
+		IsClosed() bool
 	}
 
 	// Channel is an AMQP channel interface
@@ -37,6 +38,7 @@ type (
 		Consume(queue, consumer string, opt Option) (<-chan Delivery, error)
 		Qos(prefetchCount, prefetchSize int, global bool) error
 		Close() error
+		IsClosed() bool
 		NotifyClose(chan Error) chan Error
 		Publisher
 	}

--- a/amqp/channel.go
+++ b/amqp/channel.go
@@ -342,3 +342,7 @@ func (ch *Channel) NotifyClose(c chan wabbit.Error) chan wabbit.Error {
 
 	return c
 }
+
+func (ch *Channel) IsClosed() bool {
+	return ch.Channel.IsClosed()
+}

--- a/amqp/channel.go
+++ b/amqp/channel.go
@@ -13,21 +13,16 @@ type Channel struct {
 	*amqp.Channel
 }
 
-func (ch *Channel) Publish(exc, route string, msg []byte, opt wabbit.Option) error {
-	amqpOpt, err := utils.ConvertOpt(opt)
-
-	if err != nil {
-		return err
-	}
-
-	amqpOpt.Body = msg
-
+func (ch *Channel) Publish(
+	exchange, key string,
+	mandatory, immediate bool,
+	msg amqp.Publishing) error {
 	return ch.Channel.Publish(
-		exc,   // publish to an exchange
-		route, // routing to 0 or more queues
-		false, // mandatory
-		false, // immediate
-		amqpOpt,
+		exchange,  // publish to an exchange
+		key,       // routing to 0 or more queues
+		mandatory, // mandatory
+		immediate, // immediate
+		msg,
 	)
 }
 
@@ -344,5 +339,12 @@ func (ch *Channel) NotifyClose(c chan wabbit.Error) chan wabbit.Error {
 }
 
 func (ch *Channel) IsClosed() bool {
-	return ch.Channel.IsClosed()
+	return ch.Channel == nil || ch.Channel.IsClosed()
+}
+
+func (ch *Channel) PublishWithDeferredConfirm(
+	exchange, key string,
+	mandatory, immediate bool,
+	msg amqp.Publishing) (*amqp.DeferredConfirmation, error) {
+	return ch.Channel.PublishWithDeferredConfirm(exchange, key, mandatory, immediate, msg)
 }

--- a/amqp/dial.go
+++ b/amqp/dial.go
@@ -161,5 +161,5 @@ func (conn *Conn) Channel() (wabbit.Channel, error) {
 }
 
 func (conn *Conn) IsClosed() bool {
-	return conn.Connection.IsClosed()
+	return conn.Connection == nil || conn.Connection.IsClosed()
 }

--- a/amqp/dial.go
+++ b/amqp/dial.go
@@ -159,3 +159,7 @@ func (conn *Conn) Channel() (wabbit.Channel, error) {
 
 	return &Channel{ch}, nil
 }
+
+func (conn *Conn) IsClosed() bool {
+	return conn.Connection.IsClosed()
+}

--- a/amqp/dial.go
+++ b/amqp/dial.go
@@ -30,7 +30,7 @@ func doDial(conn *Conn, dialFn func() error) (*Conn, error) {
 }
 
 // Dial connects to an AMQP broker, with defaults
-func Dial(uri string) (*Conn, error) {
+func Dial(uri string) (wabbit.Conn, error) {
 	conn := &Conn{}
 
 	return doDial(conn, func() error {

--- a/amqp/publisher.go
+++ b/amqp/publisher.go
@@ -1,6 +1,9 @@
 package amqp
 
-import "github.com/NeowayLabs/wabbit"
+import (
+	"github.com/NeowayLabs/wabbit"
+	amqp "github.com/rabbitmq/amqp091-go"
+)
 
 type Publisher struct {
 	conn    wabbit.Conn
@@ -27,12 +30,16 @@ func NewPublisher(conn wabbit.Conn, channel wabbit.Channel) (*Publisher, error) 
 	return &pb, nil
 }
 
-func (pb *Publisher) Publish(exc string, route string, message []byte, opt wabbit.Option) error {
+func (pb *Publisher) Publish(
+	exchange, key string,
+	mandatory, immediate bool,
+	msg amqp.Publishing) error {
 	err := pb.channel.Publish(
-		exc,   // publish to an exchange
-		route, // routing to 0 or more queues
-		message,
-		opt,
+		exchange, // publish to an exchange
+		key,      // routing to 0 or more queues
+		mandatory,
+		immediate,
+		msg,
 	)
 
 	return err

--- a/amqp_test.go
+++ b/amqp_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NeowayLabs/wabbit"
 	"github.com/NeowayLabs/wabbit/amqptest"
 	"github.com/NeowayLabs/wabbit/amqptest/server"
+	"github.com/rabbitmq/amqp091-go"
 )
 
 func TestBasicUsage(t *testing.T) {
@@ -101,7 +102,7 @@ func pub(conn wabbit.Conn, t *testing.T, done chan bool) {
 		goto PubError
 	}
 
-	err = publisher.Publish("test", "wabbit-test-route", []byte("msg1"), nil)
+	err = publisher.Publish("test", "wabbit-test-route", false, false, amqp091.Publishing{Body: []byte("msg1")})
 
 	if err != nil {
 		goto PubError
@@ -113,7 +114,7 @@ func pub(conn wabbit.Conn, t *testing.T, done chan bool) {
 		goto PubError
 	}
 
-	err = publisher.Publish("test", "wabbit-test-route", []byte("msg2"), nil)
+	err = publisher.Publish("test", "wabbit-test-route", false, false, amqp091.Publishing{Body: []byte("msg2")})
 
 	if err != nil {
 		goto PubError
@@ -125,7 +126,7 @@ func pub(conn wabbit.Conn, t *testing.T, done chan bool) {
 		goto PubError
 	}
 
-	err = publisher.Publish("test", "wabbit-test-route", []byte("msg3"), nil)
+	err = publisher.Publish("test", "wabbit-test-route", false, false, amqp091.Publishing{Body: []byte("msg3")})
 
 	if err != nil {
 		goto PubError

--- a/amqptest/dial.go
+++ b/amqptest/dial.go
@@ -163,11 +163,13 @@ func (conn *Conn) Close() error {
 
 	// enables AutoRedial to gracefully shutdown
 	// This isn't wabbit stuff. It's the rabbitmq/amqp way of notify the shutdown
-	conn.errSpread.Write(nil)
+
 	if !conn.hasAutoRedial {
+		conn.defErrDone <- true
+		conn.errSpread.Write(nil)
 		conn.errSpread.Delete(conn.errChan)
 		close(conn.errChan)
-		conn.defErrDone <- true
+		close(conn.defErrDone)
 	}
 
 	return nil

--- a/amqptest/dial.go
+++ b/amqptest/dial.go
@@ -32,7 +32,7 @@ type Conn struct {
 
 // Dial mock the connection dialing to rabbitmq and
 // returns the established connection or error if something goes wrong
-func Dial(amqpuri string) (*Conn, error) {
+func Dial(amqpuri string) (wabbit.Conn, error) {
 	conn := &Conn{
 		amqpuri:    amqpuri,
 		errSpread:  utils.NewErrBroadcast(),
@@ -177,4 +177,9 @@ func (conn *Conn) Close() error {
 // Channel creates a new fake channel
 func (conn *Conn) Channel() (wabbit.Channel, error) {
 	return conn.amqpServer.CreateChannel(conn.ConnID, conn)
+}
+
+// Channel creates a new fake channel
+func (conn *Conn) IsClosed() bool {
+	return !conn.isConnected
 }

--- a/amqptest/dial.go
+++ b/amqptest/dial.go
@@ -163,9 +163,7 @@ func (conn *Conn) Close() error {
 
 	// enables AutoRedial to gracefully shutdown
 	// This isn't wabbit stuff. It's the rabbitmq/amqp way of notify the shutdown
-	if conn.hasAutoRedial {
-		conn.errSpread.Write(nil)
-	} else {
+	if !conn.hasAutoRedial {
 		conn.errSpread.Delete(conn.errChan)
 		close(conn.errChan)
 		conn.defErrDone <- true

--- a/amqptest/dial.go
+++ b/amqptest/dial.go
@@ -163,6 +163,7 @@ func (conn *Conn) Close() error {
 
 	// enables AutoRedial to gracefully shutdown
 	// This isn't wabbit stuff. It's the rabbitmq/amqp way of notify the shutdown
+	conn.errSpread.Write(nil)
 	if !conn.hasAutoRedial {
 		conn.errSpread.Delete(conn.errChan)
 		close(conn.errChan)

--- a/amqptest/dial_test.go
+++ b/amqptest/dial_test.go
@@ -39,8 +39,7 @@ func TestDial(t *testing.T) {
 	amqpuri := "amqp://guest:guest@localhost:35672/%2f"
 
 	// Should fail
-	conn, err := Dial(amqpuri)
-
+	_, err := Dial(amqpuri)
 	if err == nil {
 		t.Error("No backend started... Should fail")
 		return
@@ -56,11 +55,20 @@ func TestDial(t *testing.T) {
 		return
 	}
 
-	conn, err = Dial(amqpuri)
+	conn, err := Dial(amqpuri)
 
 	if err != nil || conn == nil {
 		t.Error(err)
 		return
+	}
+
+	if conn.IsClosed() {
+		t.Error("Open Connection should not say its closed")
+	}
+
+	conn.Close()
+	if !conn.IsClosed() {
+		t.Error("Closed Connection should not say its open")
 	}
 
 	server.Stop()

--- a/amqptest/publisher.go
+++ b/amqptest/publisher.go
@@ -1,6 +1,9 @@
 package amqptest
 
-import "github.com/NeowayLabs/wabbit"
+import (
+	"github.com/NeowayLabs/wabbit"
+	amqp "github.com/rabbitmq/amqp091-go"
+)
 
 type Publisher struct {
 	channel wabbit.Publisher
@@ -24,12 +27,13 @@ func NewPublisher(conn wabbit.Conn, channel wabbit.Channel) (*Publisher, error) 
 	}, nil
 }
 
-func (pb *Publisher) Publish(exc string, route string, message []byte, opt wabbit.Option) error {
+func (pb *Publisher) Publish(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
 	err := pb.channel.Publish(
-		exc,   // publish to an exchange
-		route, // routing to 0 or more queues
-		message,
-		opt,
+		exchange, // publish to an exchange
+		key,      // routing to 0 or more queues
+		mandatory,
+		immediate,
+		msg,
 	)
 
 	return err

--- a/amqptest/server/channel.go
+++ b/amqptest/server/channel.go
@@ -345,6 +345,7 @@ func (ch *Channel) Close() error {
 		}
 		ch.publishListeners = []chan wabbit.Confirmation{}
 		ch.isConnected = false
+		ch.errSpread.Write(nil)
 	}
 
 	return nil

--- a/amqptest/server/channel_test.go
+++ b/amqptest/server/channel_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"testing"
 	"time"
+
+	"github.com/rabbitmq/amqp091-go"
 )
 
 func TestBasicConsumer(t *testing.T) {
@@ -42,7 +44,7 @@ func TestBasicConsumer(t *testing.T) {
 		return
 	}
 
-	err = ch.Publish("neoway", "process.data", []byte("teste"), nil)
+	err = ch.Publish("neoway", "process.data", false, false, amqp091.Publishing{Body: []byte("teste")})
 
 	if err != nil {
 		t.Error(err)
@@ -92,7 +94,7 @@ func TestWorkerQueue(t *testing.T) {
 		return
 	}
 
-	err = ch.Publish("", q.Name(), []byte("teste"), nil)
+	err = ch.Publish("", q.Name(), false, false, amqp091.Publishing{Body: []byte("teste")})
 
 	if err != nil {
 		t.Error(err)
@@ -144,7 +146,7 @@ func TestUnackedMessagesArentLost(t *testing.T) {
 		return
 	}
 
-	err = ch.Publish("neoway", "process.data", []byte("teste"), nil)
+	err = ch.Publish("neoway", "process.data", false, false, amqp091.Publishing{Body: []byte("teste")})
 
 	if err != nil {
 		t.Error(err)
@@ -262,7 +264,7 @@ func TestAckedMessagesAreCommited(t *testing.T) {
 		return
 	}
 
-	err = ch.Publish("neoway", "process.data", []byte("teste"), nil)
+	err = ch.Publish("neoway", "process.data", false, false, amqp091.Publishing{Body: []byte("teste")})
 
 	if err != nil {
 		t.Error(err)
@@ -367,7 +369,7 @@ func TestPublishThenConsumeAck(t *testing.T) {
 		return
 	}
 
-	err = ch.Publish("neoway", "process.data", []byte("teste"), nil)
+	err = ch.Publish("neoway", "process.data", false, false, amqp091.Publishing{Body: []byte("teste")})
 
 	if err != nil {
 		t.Error(err)
@@ -465,7 +467,7 @@ func TestNAckedMessagesAreRequeued(t *testing.T) {
 		return
 	}
 
-	err = ch.Publish("neoway", "process.data", []byte("teste"), nil)
+	err = ch.Publish("neoway", "process.data", false, false, amqp091.Publishing{Body: []byte("teste")})
 
 	if err != nil {
 		t.Error(err)
@@ -584,7 +586,7 @@ func TestNAckedMessagesAreRejectedWhenRequested(t *testing.T) {
 		return
 	}
 
-	err = ch.Publish("neoway", "process.data", []byte("teste"), nil)
+	err = ch.Publish("neoway", "process.data", false, false, amqp091.Publishing{Body: []byte("teste")})
 
 	if err != nil {
 		t.Error(err)
@@ -701,7 +703,7 @@ func TestRejectedMessagesAreRequeuedWhenRequested(t *testing.T) {
 		return
 	}
 
-	err = ch.Publish("neoway", "process.data", []byte("teste"), nil)
+	err = ch.Publish("neoway", "process.data", false, false, amqp091.Publishing{Body: []byte("teste")})
 
 	if err != nil {
 		t.Error(err)
@@ -820,7 +822,7 @@ func TestRejectedMessagesAreRejectedWhenRequested(t *testing.T) {
 		return
 	}
 
-	err = ch.Publish("neoway", "process.data", []byte("teste"), nil)
+	err = ch.Publish("neoway", "process.data", false, false, amqp091.Publishing{Body: []byte("teste")})
 
 	if err != nil {
 		t.Error(err)

--- a/amqptest/server/channel_test.go
+++ b/amqptest/server/channel_test.go
@@ -55,6 +55,18 @@ func TestBasicConsumer(t *testing.T) {
 		t.Errorf("Failed to publish message to specified route")
 		return
 	}
+
+	if ch.IsClosed() {
+		t.Error("Expected a valid Channel to return false before closing")
+		return
+	}
+
+	// Closing a channel should make IsClosed return true
+	ch.Close()
+	if !ch.IsClosed() {
+		t.Error("Expected Channel to return true after closing")
+		return
+	}
 }
 
 func TestWorkerQueue(t *testing.T) {

--- a/amqptest/server/server.go
+++ b/amqptest/server/server.go
@@ -59,7 +59,7 @@ func (s *AMQPServer) CreateChannel(connID string, conn wabbit.Conn) (wabbit.Chan
 
 	if len(channels) >= MaxChannels {
 		return nil, fmt.Errorf("Channel quota exceeded, Wabbit"+
-			" supports only %d fake channels for tests.", MaxChannels)
+			" supports only %d fake channels for tests", MaxChannels)
 	}
 
 	ch := NewChannel(s.vhost)
@@ -149,8 +149,8 @@ func getServer(amqpuri string) (*AMQPServer, error) {
 
 	amqpServer := servers[amqpuri]
 
-	if amqpServer == nil || amqpServer.running == false {
-		return nil, errors.New("Network unreachable")
+	if amqpServer == nil || !amqpServer.running {
+		return nil, errors.New("network unreachable")
 	}
 
 	return amqpServer, nil
@@ -171,7 +171,7 @@ func Close(amqpuri string, connID string) error {
 	amqpServer, err := getServer(amqpuri)
 
 	if err != nil {
-		return errors.New("Failed to close connection")
+		return errors.New("failed to close connection")
 	}
 
 	amqpServer.delNotify(connID)


### PR DESCRIPTION
- Using connection interface as a return type for dial to be used in tests, this way an interface can be used instead of a concrete type when using the `amqptest Connection Dial` method
- Added `IsClosed` method to Channel and Connection tests to them
- Fixed some linter warnings